### PR TITLE
Opt htmlbars-ast-plugin into parallel Babel builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,26 @@ module.exports = {
   name: require('./package').name,
 
   setupPreprocessorRegistry(type, registry) {
-    registry.add('htmlbars-ast-plugin', {
+    const plugin = this._buildPlugin();
+
+    plugin.parallelBabel = {
+      requireFile: __filename,
+      buildUsing: '_buildPlugin',
+      params: {}
+    };
+
+    registry.add('htmlbars-ast-plugin', plugin);
+  },
+
+  _buildPlugin() {
+    const SimpleSetTransform = require('./lib/simple-set-transform');
+
+    return {
       name: 'set-placeholder',
-      plugin: require('./lib/simple-set-transform'),
+      plugin: SimpleSetTransform,
       baseDir() {
         return __dirname;
-      },
-    });
-  },
+      }
+    };
+  }
 };


### PR DESCRIPTION
So this addon causes your app to opt out of [Babel parallel builds](https://github.com/babel/ember-cli-babel#parallel-builds).

## Reproduction
To reproduce you can do the following:

1. Create a new ember-cli and update dependencies
```sh
npx ember-cli new test-app && cd test-app
// Remove ember-cli-template-lint as this also does not support parallel builds
yarn remove ember-cli-template-lint
yarn add ember-simple-set-helper
```

2. Add the following to your `ember-cli-build.js` to throw a hard error on your Ember build if parallel builds aren't possible
```js
'use strict';

const EmberApp = require('ember-cli/lib/broccoli/ember-app');

module.exports = function(defaults) {
  let app = new EmberApp(defaults, {
    'ember-cli-babel': {
      throwUnlessParallelizable: true
    }
  });
  return app.toTree();
};
```

3. Run `yarn build`

It will generate the following error:
```
➜  test-app  git:(master) ✗ yarn build
yarn run v1.21.1
$ ember build
⠋ Building[broccoli-persistent-filter:Babel > [Babel: test-app]: Babel: test-app] was configured to `throwUnlessParallelizable` and was unable to parallelize a plugin.
plugins:
1: name: unknown, location: unknown

Please see: https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation for more details
```

## Change
This PR follows a pattern other ast-plugins use to opt them into parallel builds, e.g. [ember-cp-validations](https://github.com/offirgolan/ember-cp-validations/blob/master/index.js#L15).

After this change `yarn build` works correctly without no babel parallel error.