### PR TITLE
Transform to -simple-set

### DIFF
--- a/app/helpers/-simple-set.js
+++ b/app/helpers/-simple-set.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-simple-set-helper/helpers/set';

--- a/lib/simple-set-transform.js
+++ b/lib/simple-set-transform.js
@@ -10,8 +10,8 @@
   becomes
 
   ```hbs
-  {{set this "bar"}}
-  {{set this "bar" "baz"}}
+  {{-simple-set this "bar"}}
+  {{-simple-set this "bar" "baz"}}
   ```
 */
 
@@ -52,6 +52,8 @@ module.exports = class SetTransform {
         } else {
           target = b.path(targetName);
         }
+
+        node.path = b.path('-simple-set');
 
         node.params.unshift(target, b.string(key));
 


### PR DESCRIPTION
This allows the template transform to be applied twice (as it may be in
an embroider build) because it now a pure function. All instances of
`set` will be transformed so `-simple-set` so a second pass over the
same template will not attempt to transform `set` again.

This is the solution suggested by @e4f in https://github.com/embroider-build/embroider/issues/403#issuecomment-663906649 and should fix that issue.

I left the original `set` helper alone and re-exported it as `-simple-set` because, while it isn't documented I'm not certain there isn't a way to get to this helper directly by doing something like `(fn (set this 'foo') 'bar)'`. Though I don't think that would actually work, I do think it may have slipped through the `if (node.params.length > 2) {` assertion in the template transform and could do something that accidentally works in an app.

If I'm wrong about that it would make the most sense to just remove `app/helpers/set.js`. If this (or some other method) would work to access the existing `{{set}}` helper directly without a transform then it probably needs a deprecation warning.  I'm happy to make either of those changes, but I'd appreciate another set of eyes to tell me which is the right path.